### PR TITLE
Fix: critical typo in dreambooth_runpod_joepenna.ipynb

### DIFF
--- a/dreambooth_runpod_joepenna.ipynb
+++ b/dreambooth_runpod_joepenna.ipynb
@@ -394,7 +394,7 @@
     " --gpus 0, \\\n",
     " --data_root \"/workspace/Dreambooth-Stable-Diffusion/training_samples\" \\\n",
     " --max_training_steps {max_training_steps} \\\n",
-    " --class_word class_word \\\n",
+    " --class_word {class_word} \\\n",
     " --no-test"
    ]
   },


### PR DESCRIPTION
`--class_word class_word` was being used to launch training instead of the correctly templated `--class_word {class_word}`

This would cause inference to look like it doesn't work when people use prompts that lack the literal phrase `class_word` for the 'class'.