### PR TITLE
Simplify updating the token in personalized.py

### DIFF
--- a/dreambooth_runpod_joepenna.ipynb
+++ b/dreambooth_runpod_joepenna.ipynb
@@ -324,43 +324,22 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "## Edit the personalized.py file\n",
-    "Execute this cell `%load ldm/data/personalized.py`\n",
-    "\n",
-    "Change `joepenna` to whatever you want it to be (but keep the {})\n",
-    "\n",
-    "```\n",
-    "training_templates_smallest = [\n",
-    "    'joepenna {}',\n",
-    "]\n",
-    "```\n",
-    "\n",
-    "I recommend using the name of a celebrity that:\n",
-    "1) kinda looks like you.\n",
-    "2) Stable Diffusion generates well (you can check by typing their name on DreamStudio)\n",
-    "\n",
-    "Then paste this at the very top of the cell:\n",
-    "```\n",
-    "%%writefile ldm/data/personalized.py\n",
-    "```\n",
-    "\n",
-    "Then run the cell again.  This will save your changes.\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "id": "3b278d02",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%load ldm/data/personalized.py"
+    "# Specify a token for your subject\n",
+    "token = \"chris hemsworth\"\n",
+    "\n",
+    "# I recommend using the name of a celebrity that:\n",
+    "# 1) kinda looks like you.\n",
+    "# 2) Stable Diffusion generates well (you can check by typing their name on DreamStudio)\n",
+    "\n",
+    "# Update ldm/data/personalized.py file with token\n",
+    "sed_replace = f\"s/^training_templates_smallest.*/training_templates_smallest = ['{token} {{}}']/\"\n",
+    "!sed -i \"{sed_replace}\" stablediffusion-dreambooth-source/ldm/data/personalized.py"
    ]
   },
   {

--- a/ldm/data/personalized.py
+++ b/ldm/data/personalized.py
@@ -7,9 +7,7 @@ from torchvision import transforms
 
 import random
 
-training_templates_smallest = [
-    'joepenna {}',
-]
+training_templates_smallest = ['joepenna {}'] # inline to help with sed replace
 
 reg_templates_smallest = [
     '{}',


### PR DESCRIPTION
Minor update to remove the need for a user to manually update the `ldm/data/personalized.py` file and instead perform the update using `sed`.

I've updated the `personalized.py` file to make the the array inline so that the sed command is a bit simpler and more clear. If you'd rather keep the original line (not sure what linters/formatters people use in python) there is the following alternative command that will replace the multiline version.

```
sed_replace = f"s/training_templates_smallest = \[\\n    '.* {{}}',\\n\]/training_templates_smallest = \[\\n    '{token} {{}}',\\n\]/"
!sed -z "{sed_replace}" -i stablediffusion-dreambooth-source/ldm/data/personalized.py
```

If this is not something of interest please feel free to close this pull request.
Suggestions or changes to the notebook copy about the token update are welcome.