### PR TITLE
Add '--token_only' parameter

### DIFF
--- a/ldm/data/personalized.py
+++ b/ldm/data/personalized.py
@@ -22,6 +22,7 @@ class PersonalizedBase(Dataset):
                  center_crop=False,
                  mixing_prob=0.25,
                  coarse_class_text="",
+                 token_only=False,
                  reg=False
                  ):
 
@@ -35,7 +36,7 @@ class PersonalizedBase(Dataset):
         self._length = self.num_images
 
         self.placeholder_token = placeholder_token
-
+        self.token_only = token_only
         self.per_image_tokens = per_image_tokens
         self.center_crop = center_crop
         self.mixing_prob = mixing_prob
@@ -71,7 +72,10 @@ class PersonalizedBase(Dataset):
         if self.reg:
             example["caption"] = self.coarse_class_text
         else:
-            example["caption"] = f"{self.placeholder_token} {self.coarse_class_text}"
+            example["caption"] = "{token}{coarse_class}".format(
+                token=self.placeholder_token,
+                coarse_class="" if self.token_only else f" {self.coarse_class_text}"
+            )
 
         # default to score-sde preprocessing
         img = np.array(image).astype(np.uint8)

--- a/main.py
+++ b/main.py
@@ -162,6 +162,13 @@ def get_parser(**parser_kwargs):
         required=True,
         help="Unique token you want to represent your trained model. Ex: firstNameLastName.")
 
+    parser.add_argument("--token_only", 
+        type=str2bool,
+        const=True,
+        default=False,
+        nargs="?",
+        help="Train only using the token and no class.")
+
     parser.add_argument("--actual_resume", 
         type=str,
         required=True,
@@ -641,12 +648,6 @@ if __name__ == "__main__":
         trainer_opt = argparse.Namespace(**trainer_config)
         lightning_config.trainer = trainer_config
 
-        # model
-
-        # config.model.params.personalization_config.params.init_word = opt.init_word
-        # config.model.params.personalization_config.params.embedding_manager_ckpt = opt.embedding_manager_ckpt
-        # config.model.params.personalization_config.params.placeholder_tokens = opt.placeholder_tokens
-
         # if opt.init_word:
         #     config.model.params.personalization_config.params.initializer_words[0] = opt.init_word
 
@@ -656,6 +657,7 @@ if __name__ == "__main__":
         config.data.params.validation.params.coarse_class_text = opt.class_word
 
         config.data.params.train.params.placeholder_token = opt.token
+        config.data.params.train.params.token_only = opt.token_only
         config.data.params.reg.params.placeholder_token = opt.token
         config.data.params.validation.params.placeholder_token = opt.token
 


### PR DESCRIPTION
Adds a `--token_only` cli parameter to use only the token without the class when training.

Cleaner version, rebased on the main branch.
