### PR TITLE
Only list log directories that match new folder

### DIFF
--- a/dreambooth_runpod_joepenna.ipynb
+++ b/dreambooth_runpod_joepenna.ipynb
@@ -377,7 +377,7 @@
    "source": [
     "# Copy the checkpoint into our `trained_models` folder\n",
     "\n",
-    "directory_paths = !ls -d logs/*\n",
+    "directory_paths = !ls -d logs/training_images*\n",
     "last_checkpoint_file = directory_paths[-1] + \"/checkpoints/last.ckpt\"\n",
     "training_images = !find training_images/*\n",
     "date_string = !date +\"%Y-%m-%dT%H-%M-%S\"\n",


### PR DESCRIPTION
Since `training_samples` dir was renamed to `training_images` and the logs are named after the training image directory, if you happened to run this code on an instance with older logs prior to the rename of the training images directory it will make the move command move the wrong file.

Simple fix was to list on `logs/training_images*` to filter to just the latest logs.