### PR TITLE
Change `Prunin'` to `Pruning`

### DIFF
--- a/ldm/pruner.py
+++ b/ldm/pruner.py
@@ -1,5 +1,5 @@
 def prune_checkpoint(old_state):
-    print(f"Prunin' Checkpoint")
+    print(f"Pruning Checkpoint")
     pruned_checkpoint = dict()
     print(f"Checkpoint Keys: {old_state.keys()}")
     for key in old_state.keys():

--- a/prune_ckpt.py
+++ b/prune_ckpt.py
@@ -10,7 +10,7 @@ args = parser.parse_args()
 ckpt = args.ckpt
 
 def prune_it(checkpoint_path):
-    print(f"Prunin' checkpoint from path: {checkpoint_path}")
+    print(f"Pruning checkpoint from path: {checkpoint_path}")
     size_initial = os.path.getsize(checkpoint_path)
     checkpoint = torch.load(checkpoint_path, map_location="cpu")
     pruned = prune_checkpoint(checkpoint)

--- a/scripts/prune-ckpt.py
+++ b/scripts/prune-ckpt.py
@@ -10,7 +10,7 @@ args = parser.parse_args()
 ckpt = args.ckpt
 
 def prune_it(p, keep_only_ema=False):
-    print(f"prunin' in path: {p}")
+    print(f"Pruning in path: {p}")
     size_initial = os.path.getsize(p)
     nsd = dict()
     sd = torch.load(p, map_location="cpu")


### PR DESCRIPTION
* Fixed all instances of the abbreviated `Prunin'` to `Pruning` (reasoning below)
* Capitalized Pruning in `scripts/prune-ckpt.py` for consistency

As someone with both a product and a dev background I appreciate good, playful microcopy such as `Prunin'`. Unfortunately when one is searching through the source code or output for "Prune" or "Pruning" and no results come back, it isn't very helpful.

Hoping to have meatier PRs soon, but every bit helps :)