### PR TITLE
BUGFIX: Limit filename length for saved images and grid

### DIFF
--- a/scripts/stable_txt2img.py
+++ b/scripts/stable_txt2img.py
@@ -272,12 +272,12 @@ def main():
                     grid = rearrange(grid, 'n b c h w -> (n b) c h w')
                     
                     for i in range(grid.size(0)):
-                        save_image(grid[i, :, :, :], os.path.join(outpath,opt.prompt+'_{}.png'.format(i)))
+                        save_image(grid[i, :, :, :], os.path.join(outpath,opt.prompt[:180]+'_{}.png'.format(i)))
                     grid = make_grid(grid, nrow=n_rows)
 
                     # to image
                     grid = 255. * rearrange(grid, 'c h w -> h w c').cpu().numpy()
-                    Image.fromarray(grid.astype(np.uint8)).save(os.path.join(outpath, f'{prompt.replace(" ", "-")}-{grid_count:04}.jpg'))
+                    Image.fromarray(grid.astype(np.uint8)).save(os.path.join(outpath, f'{prompt[:180].replace(" ", "-")}-{grid_count:04}.jpg'))
                     grid_count += 1
                     
                     


### PR DESCRIPTION
# 🐛  Bug

`scripts/stable_txt2img.py` generates the filename of the output images and the grid images from the `prompt` argument.

If the prompt argument is too long, the script crashes with this error:

```sh
Traceback (most recent call last):
  File "scripts/stable_txt2img.py", line 292, in <module>
    main()
  File "scripts/stable_txt2img.py", line 275, in main
    save_image(grid[i, :, :, :], os.path.join(outpath,opt.prompt[:1800]+'_{}.png'.format(i)))
  File "/opt/conda/lib/python3.7/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/torchvision/utils.py", line 160, in save_image
    im.save(fp, format=format)
  File "/opt/conda/lib/python3.7/site-packages/PIL/Image.py", line 2209, in save
    fp = builtins.open(filename, "w+b")
OSError: [Errno 36] File name too long: 'outputs/txt2img-samples/talAter person riding a unicorn as a digital painting of afrofuturism, from left, Makoto Shinkai, Stanley Artgerm Lau, WLOP, Rossdraws, James Jean, Andrei Riabovitchev, Marc Simonetti, krenz cushart, Sakimichan, D&D trending on ArtStation, digital  person riding a unicorn as a digital painting of tracer from Overwatch, artstation, CGSociety, by artgerm, by rossdraws, anime style_0.png'
```

# 🔧  Fix

This fix truncates the filename to something more manageable.

# 💡 Note

 Technically, the OS supports longer filenames than proposed in this PR. However, the longer filenames give JupyterLab indigestion so this PR shortens the filename to 180 chars (plus the suffix).
​
![CleanShot 2022-11-06 at 15 34 55](https://user-images.githubusercontent.com/926653/200198918-c6cb4b05-e24b-469d-98c3-c233abcf4427.jpg)
