### PR TITLE
fix ddim index out of bound as per https://github.com/invoke-ai/Invok…

### DIFF
--- a/ldm/modules/diffusionmodules/util.py
+++ b/ldm/modules/diffusionmodules/util.py
@@ -46,7 +46,8 @@ def make_beta_schedule(schedule, n_timestep, linear_start=1e-4, linear_end=2e-2,
 def make_ddim_timesteps(ddim_discr_method, num_ddim_timesteps, num_ddpm_timesteps, verbose=True):
     if ddim_discr_method == 'uniform':
         c = num_ddpm_timesteps // num_ddim_timesteps
-        ddim_timesteps = np.asarray(list(range(0, num_ddpm_timesteps, c)))
+        # ddim_timesteps = np.asarray(list(range(0, num_ddpm_timesteps, c)))
+        ddim_timesteps = (np.arange(0, num_ddim_timesteps) * c).astype(int)
     elif ddim_discr_method == 'quad':
         ddim_timesteps = ((np.linspace(0, np.sqrt(num_ddpm_timesteps * .8), num_ddim_timesteps)) ** 2).astype(int)
     else:


### PR DESCRIPTION
Hi @JoePenna - thank you for this repository, it was very helpful to me as I was trying to fine tune my own StableDiffusion model. I was playing around with increasing the number of `ddim_steps` using the `scripts/stable_txt2img.py` script, and started running into a error saying `IndexError: index 1000 is out of bounds for dimension 0 with size 1000` if I increased the number of steps to, say, 300. 

Googling around, I saw that someone had fixed this error in their own copy of this code with this PR: https://github.com/invoke-ai/InvokeAI/commit/1c2bd275fe5c1021feaf1cbe52f471f7d712cfc3

This PR applies the same one-line fix - I made it to your code that I had download locally and generating images using my fine-tuned model worked (i.e., I no longer saw the "index 1000" error) so I thought I would contribute it back to your code.