### PR TITLE
Regularization image dirname

### DIFF
--- a/dreambooth_colab_joepenna.ipynb
+++ b/dreambooth_colab_joepenna.ipynb
@@ -1,32 +1,17 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
  "cells": [
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "#@title Load repo (if needed)\n",
     "!git clone https://github.com/JoePenna/Dreambooth-Stable-Diffusion\n",
     "%cd Dreambooth-Stable-Diffusion"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -65,31 +50,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "#@title # Required - Navigate back to the directory.\n",
     "%cd Dreambooth-Stable-Diffusion"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "6tjx0HcjesFo"
+   },
+   "outputs": [],
    "source": [
     "#@markdown Hugging Face Login\n",
     "from huggingface_hub import notebook_login\n",
     "\n",
     "notebook_login()"
-   ],
-   "metadata": {
-    "id": "6tjx0HcjesFo"
-   },
-   "execution_count": 1,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "O15vMMhCevib"
+   },
+   "outputs": [],
    "source": [
     "#@markdown Download the 1.4 sd model\n",
     "from IPython.display import clear_output\n",
@@ -106,15 +96,15 @@
     "!mv {actual_locations_of_model_blob[-1]} model.ckpt\n",
     "clear_output()\n",
     "print(\"✅ model.ckpt successfully downloaded\")\n"
-   ],
-   "metadata": {
-    "id": "O15vMMhCevib"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "N96aedTtfBjO"
+   },
+   "outputs": [],
    "source": [
     "#@title # Download Regularization Images\n",
     "#@markdown We’ve created the following image sets\n",
@@ -129,15 +119,15 @@
     "\n",
     "!mkdir -p regularization_images/{dataset}\n",
     "!mv -v Stable-Diffusion-Regularization-Images-{dataset}/{dataset}/*.* regularization_images/{dataset}"
-   ],
-   "metadata": {
-    "id": "N96aedTtfBjO"
-   },
-   "execution_count": 2,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "A7hmdOdOfGzs"
+   },
+   "outputs": [],
    "source": [
     "#@title # Training Images\n",
     "#@markdown ## Upload your training images\n",
@@ -166,15 +156,15 @@
     " print(\"❌ no training images found. Please upload images to training_images\")\n",
     "else:\n",
     " print(\"✅ \" + str(len(training_images_file_paths)) + \" training images found\")\n"
-   ],
-   "metadata": {
-    "id": "A7hmdOdOfGzs"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "m2o_fFFvfxHi"
+   },
+   "outputs": [],
    "source": [
     "#@title # Training\n",
     "\n",
@@ -205,15 +195,15 @@
     " --class_word \"{class_word}\" \\\n",
     " --token \"{token}\" \\\n",
     " --no-test"
-   ],
-   "metadata": {
-    "id": "m2o_fFFvfxHi"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Ll_ZIFNUulKJ"
+   },
+   "outputs": [],
    "source": [
     "#@title # Copy and name the checkpoint file\n",
     "\n",
@@ -229,27 +219,44 @@
     "!mv \"{last_checkpoint_file}\" \"trained_models/{file_name}\"\n",
     "\n",
     "print(\"Download your trained model file from trained_models/\" + file_name + \" and use in your favorite Stable Diffusion repo!\")"
-   ],
-   "metadata": {
-    "id": "Ll_ZIFNUulKJ"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "mkidEm4evn1J"
+   },
+   "outputs": [],
    "source": [
     "#@title Save model in google drive\n",
     "from google.colab import drive\n",
     "drive.mount('/content/drive')\n",
     "\n",
     "!cp trained_models/{file_name} /content/drive/MyDrive/{file_name}"
-   ],
-   "metadata": {
-    "id": "mkidEm4evn1J"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.3 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.3"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "99cb154694ef233467f574b5f2483eef2931fc8692c01c95dc679d143515eea0"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/dreambooth_runpod_joepenna.ipynb
+++ b/dreambooth_runpod_joepenna.ipynb
@@ -178,7 +178,8 @@
     " --ckpt model.ckpt \\\n",
     " --prompt {self_generated_files_prompt}\n",
     "\n",
-    "dataset=self_generated_files_prompt\n",
+    "import re \n",
+    "dataset=re.(\"[ ]+\", \"_\",self_generated_files_prompt)\n",
     "\n",
     "!mkdir -p regularization_images/{dataset}\n",
     "!mv outputs/txt2img-samples/*.jpg regularization_images/{dataset}"

--- a/dreambooth_runpod_joepenna.ipynb
+++ b/dreambooth_runpod_joepenna.ipynb
@@ -48,6 +48,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# BUILD ENV\n",
@@ -68,20 +71,17 @@
     "!pip install -qq diffusers[\"training\"]==0.3.0 transformers ftfy\n",
     "!pip install huggingface_hub\n",
     "!pip install captionizer==1.0.1\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Hugging Face Token\n",
     "Grab your hugging face token from here https://huggingface.co/settings/tokens and paste into the next cell (HUGGING_FACE_API_TOKEN_HERE)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -98,17 +98,20 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Download the 1.5 model from hugging face\n",
     "You can also provide your own v1.* model for training by uploading it and renaming it to \"model.ckpt\".  It should be in the same directory as dreambooth_runpod_joepenna.ipynb"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Download the 1.5 sd model\n",
@@ -126,10 +129,7 @@
     "!mv {actual_locations_of_model_blob[-1]} model.ckpt\n",
     "clear_output()\n",
     "print(\"✅ model.ckpt successfully downloaded\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -181,7 +181,7 @@
     "dataset=self_generated_files_prompt\n",
     "\n",
     "!mkdir -p regularization_images/{dataset}\n",
-    "!mv outputs/txt2img-samples/*.png regularization_images/{dataset}"
+    "!mv outputs/txt2img-samples/*.jpg regularization_images/{dataset}"
    ]
   },
   {
@@ -201,6 +201,9 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Download pre-generated regularization images\n",
     "We've created the following image sets\n",
@@ -211,10 +214,7 @@
     "`person_ddim`\n",
     "`woman_ddim` - provided by David Bielejeski - ddim @ 50 steps, CFG 10.0\n",
     "`person_ddim` is recommended"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -236,6 +236,9 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Upload your training images\n",
     "Upload 10-20 images of someone to\n",
@@ -253,14 +256,14 @@
     "The images should be:\n",
     "\n",
     "- as close as possible to the kind of images you're trying to make"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "#@markdown Add here the URLs to the images of the subject you are adding\n",
@@ -272,10 +275,7 @@
     " \"https://i.imgur.com/test5.png\",\n",
     " # You can add additional images here -- about 20-30 images in different\n",
     "]"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -452,6 +452,9 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Optional - Upload to google drive\n",
     "* run the following commands in a new `terminal` in the `Dreambooth-Stable-Diffusion` directory\n",
@@ -459,10 +462,7 @@
     "* `./gdrive about`\n",
     "* `paste your token here after navigating to the link`\n",
     "* `./gdrive upload trained_models/{file_name.ckpt}`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -506,7 +506,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.3 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -520,11 +520,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.3"
   },
   "vscode": {
    "interpreter": {
-    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+    "hash": "99cb154694ef233467f574b5f2483eef2931fc8692c01c95dc679d143515eea0"
    }
   }
  },


### PR DESCRIPTION
**Runpod Notebook Only**

Regularization Images cell takes `self_generated_files_prompt` for generating images, but also uses this variable as `dataset` later on. If the prompt has spaces, this ruins the directory name when the folder is being made. Added a small fix to have the `dataset` variable = `self_generated_files_prompt` with all spaces replaced with `_`