### PR TITLE
Update environment.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Now, if you wanna try to do this... please read the warnings below first:
   - You can now run this on a GPU with **24GB of VRAM** (e.g. 3090). Training will be slower, and you'll need to be sure this is the *only* program running.
   - If, like myself, you don't happen to own one of those, I'm including a Jupyter notebook here to help you run it on a rented cloud computing platform. 
   - It's currently tailored to [runpod.io](https://runpod.io?ref=n8yfwyum) and [vast.ai](http://console.vast.ai/?ref=47390) 
-  - We do support a colab notebook as well: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JoePenna/Dreambooth-Stable-Diffusion/blob/main/dreambooth_colab_joepenna.ipynb)
+  - We do support a colab notebook as well: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JoePenna/Dreambooth-Stable-Diffusion/blob/main/dreambooth_google_colab_joepenna.ipynb)
   
 - This implementation does not fully implement Google's ideas on how to preserve the latent space.
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,10 +3,11 @@ channels:
   - pytorch
   - nvidia
   - defaults
+  - conda-forge
 dependencies:
   - python=3.10
   - pip=22.2.2
-  - cudatoolkit=11.3
+  - cudatoolkit=11.8
   - pytorch
   - torchvision
   - pytorch-cuda=11.7


### PR DESCRIPTION
-Added conda-forge channel (for cudatoolkit 11.8 availability) 
-Changed cudatoolkit=11.8

Under ubuntu 22.04, cudatoolkit 11.3 and 11.7 were throwing errors. 
`cudatoolkit=11.3` :
"ImportError: /home/user/anaconda3/envs/db-joepenna2/lib/python3.10/site-packages/torch/lib/libtorch_cuda.so: 
undefined symbol: cudaGraphInstantiateWithFlags, version libcudart.so.11.0"

`cudatoolkit=11.7`: 
"torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 23.65 GiB total capacity; 22.44 GiB already allocated; 10.75 MiB free; 22.77 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF"

No problems with 11.8. Also tested under Windows 11.

------------
Updated `Open In Colab` link. 