### PR TITLE
Fix Docker image name in README.md for RunPod execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ From within the My Pods page,
   - `runpod/pytorch:3.10-2.0.1-120-devel`
   - `runpod/pytorch:3.10-2.0.1-118-runtime`
   - `runpod/pytorch:3.10-2.0.0-117`
-  - `runpod/pytorch-3.10-1.13.1-116`
+  - `runpod/pytorch:3.10-1.13.1-116`
 - Click Save.
 - Restart your pod
 


### PR DESCRIPTION
An obvious fix to the Docker image name for the recommended PyTorch 1.13.1 version in RunPod.

As an aside, do you know if the PyTorch 2.0.0 and 2.0.1 versions require more VRAM? I hit a CUDA out of memory issue using `runpod/pytorch:3.10-2.0.1-120-devel` on a 24GB VRAM pod (RTX 3090 or A5000; can't quite remember which).

Do you have any suggestion on when to use which Docker image/PyTorch image?

Edit: it's suggested in https://github.com/JoePenna/Dreambooth-Stable-Diffusion/issues/194 that perhaps 1.13.1 consumes less VRAM, albeit in a different environment.