### PR TITLE
show progress when copying the model files in google_colab

### DIFF
--- a/dreambooth_google_colab_joepenna.ipynb
+++ b/dreambooth_google_colab_joepenna.ipynb
@@ -236,7 +236,7 @@
     "drive.mount('/content/drive')\n",
     "\n",
     "# copy all ckpt files to google drive root dir\n",
-    "!cp trained_models/*.ckpt /content/drive/MyDrive"
+    "!rsync --progress trained_models/*.ckpt /content/drive/MyDrive"
    ]
   }
  ],


### PR DESCRIPTION
Every step in the notebooks show the progress, it would be nice to see the model transfer/download progress to google drive.